### PR TITLE
Added-Snapshot of the OS disk first and also added two new scripts to allow customers to run this in a hybrid automated fashion.

### DIFF
--- a/RecoverVm/1_CreateVMRecovery.ps1
+++ b/RecoverVm/1_CreateVMRecovery.ps1
@@ -18,9 +18,17 @@ if ( ! $Sub )
 $results = AttachOsDiskAsDataDiskToRecoveryVm $ServiceName $VMName
 $recoVM = $results[$results.count -1]
 
-RunRepairDataDiskFromRecoveryVm $ServiceName ($recoVM.RoleName)
+write-host ('='*47)
+write-host "Next Steps"
+write-host ('='*47)
+write-host "RDP into the $($recoVM.RoleName) and take all the necessary steps to fix the OS Disk that is attached as the datadisk"
+Write-Host "After the OS Disk has been fixed run the following script to Recreate the VM with the fixed OS Disk"
+write-host ".\2_RecreateOriginalVM.ps1 -ServiceName $ServiceName -RecoVMName $($recoVM.RoleName)"
 
-RecreateVmFromVhd $ServiceName $recoVM.RoleName $true
+
+#As per discussion with Ram, this step will be manually run
+#RunRepairDataDiskFromRecoveryVm $ServiceName ($recoVM.RoleName)
+
 
 
 

--- a/RecoverVm/2_RecreateOriginalVM.ps1
+++ b/RecoverVm/2_RecreateOriginalVM.ps1
@@ -1,0 +1,29 @@
+﻿#.\RecoverVM.ps1 -ServiceName testvip-d7zzhcnb -VMName testvip
+#cd E:\git\github\RecoverVm
+Param(
+    [Parameter(Mandatory=$true)][string]$ServiceName ,
+    [Parameter(Mandatory=$true)][string]$RecoVMName 
+)
+
+$Sub = Get-AzureSubscription -Current
+if ( ! $Sub ) 
+{
+    Write-Output "no current subscription set - please run add-azureaccount + select-azuresubscription -current first for the subscription containing your target vm!"
+    return
+}
+
+#. $PSScriptRoot\AttachOsDiskAsDataDiskToRecoveryVm.ps1 
+. $PSScriptRoot\RecreateVmFromVhd.ps1 
+#. $PSScriptRoot\RunRepairDataDiskFromRecoveryVm.ps1 
+
+
+#$results = AttachOsDiskAsDataDiskToRecoveryVm $ServiceName $VMName
+#$recoVM = $results[$results.count -1]
+
+
+
+#As per discussion with Ram, this step will be manually run
+#RunRepairDataDiskFromRecoveryVm $ServiceName ($recoVM.RoleName)
+
+
+RecreateVmFromVhd $ServiceName $RecoVMName $true

--- a/RecoverVm/readme.md
+++ b/RecoverVm/readme.md
@@ -19,14 +19,27 @@ In such cases it is a common practice to recover the problem VM by performing th
 ##  When would you use the script?
 If a Windows VM in Azure does not boot. Typically in this scenario VM screenshot from [boot diagnostics] (https://azure.microsoft.com/en-us/blog/boot-diagnostics-for-virtual-machines-v2/) does not show login screen but a boot issue.
 
-# Execution guidance
+# Execution guidance (Option 1 Fully Automated but limited OS Disk fixes)
 - download and extract the entire project folder https://github.com/Azure/azure-support-scripts/archive/master.zip to c:\azscripts\ (or custom)
 - Or pull it using git client github-windows://openRepo/https://github.com/Azure/azure-support-scripts
-- Open Azure Powershell and and execute 
+- Open Azure Powershell and and execute
+ 
 
 ```PowerShell
 c:\azscripts\RecoverVM\RecoverVM.ps1 MYCLOUDSERVICENAME MYVMNAME
 ```
+
+# Execution guidance (OPTION 2 Phased Approach more flexible needs manual intervention to fix OS Disk)
+- download and extract the entire project folder https://github.com/Azure/azure-support-scripts/archive/master.zip to c:\azscripts\ (or custom)
+- Or pull it using git client github-windows://openRepo/https://github.com/Azure/azure-support-scripts
+- Open Azure Powershell and and execute
+
+```PowerShell
+Step 1 c:\azscripts\RecoverVM\1_CreateVMRecovery.ps1 MYCLOUDSERVICENAME MYVMNAME
+Step 2 Log to the Recovery VM created in step 1 fix OSDisk issues and follow instruction to run
+Step 3 c:\azscripts\RecoverVM\2_RecreateOriginalVM MYCLOUDSERVICENAME <NameofRecoveryVM that was created in step 1>
+```
+
 
 - follow the instructions and be patient (it may take between 15mins and multiple hours [if disk repair takes long])
 


### PR DESCRIPTION
As per the PR suggestion by Nikhil added a section to first take a snapshot of the OSdisk, in addition to that per Ram 'Kakani's suggestion added two additional scripts to allow ccustomers to run this in two phases, first one to create the recovery VM and then allow the customer/Support to go in and make the necessary changes to the OS Disk and then run the secon script to recereate the original VM with the fixed os Disk.